### PR TITLE
Problem types filtering

### DIFF
--- a/sweri_utils/files.py
+++ b/sweri_utils/files.py
@@ -133,4 +133,4 @@ def gdb_to_postgres(url, gdb_name, projection, fc_name, postgres_table_name, sde
 
     #Remove gdb
     arcpy.management.Delete(gdb_path)
-    logging.info(f'{gdb_path} deleted')
+    logging.info(f'{gdb_path} gdb deleted')


### PR DESCRIPTION
Filters unwanted types out of treatment index based on the excel file in issue #1088. The types to be excluded have been added as rows to the common_attributes_lookup table with the filter = 'type' and included = 'FALSE'. These are switched from r5 'PASS' to r5 'FAIL' excluding them from import. 