### PR TITLE
Indexing and table cycling update for intersections processing

### DIFF
--- a/gp_tool/aoi_intersections.py
+++ b/gp_tool/aoi_intersections.py
@@ -1,5 +1,3 @@
-import json
-
 import arcpy
 from os import path
 import sys, os
@@ -15,71 +13,15 @@ from arcpy.management import CreateTable
 #                         stderrToServer=True)
 #########################################################map
 
-def configure_intersection_sources(sde_connection_file, schema):
-    """
-    configures intersection sources fetched from intersection source list
-    :param sde_connection_file: sde connection file path
-    :param schema: target schema
-    :return: intersection sources and intersection targets dictionaries
-    """
-    intersect_sources = {}
-    intersect_targets = {}
-    domains = fetch_domains(sde_connection_file,
-                            path.join(sde_connection_file, 'sweri.{}.intersections_source_list'.format(schema)))
-    fields = ['source', 'id_source', 'uid_fields', 'use_as_target', 'source_type', 'name']
-    with arcpy.da.SearchCursor(path.join(sde_connection_file, 'sweri.{}.intersections_source_list'.format(schema)),
-                               field_names=fields, sql_clause=(None, "ORDER BY source_type ASC")) as source_cursor:
-        for r in source_cursor:
-            s = {'source': r[0], 'id': r[2], 'source_type': r[4]}
-            if 'name' in domains and r[5] in domains['name']:
-                s['name'] = domains['name'][r[5]]
-            intersect_sources[r[1]] = s
-            if r[3] == 1:
-                intersect_targets[r[1]] = s
-    return intersect_sources, intersect_targets
-
-
-def update_schema_for_intersections_insert(intersect_result, fc_1_name, fc_2_name):
-    # update existing fields with new id column names
-    arcpy.management.AlterField(intersect_result, 'unique_id', 'id_1', 'id_1')
-    arcpy.management.AlterField(intersect_result, 'unique_id_1', 'id_2', 'id_2')
-    arcpy.management.AlterField(intersect_result, 'feat_source', 'id_1_source', 'id_1_source')
-    arcpy.management.AlterField(intersect_result, 'feat_source_1', 'id_2_source', 'id_2_source')
-    # add field names
-    arcpy.management.CalculateField(intersect_result, 'id_1_source', "'{}'".format(fc_1_name), 'PYTHON3')
-    arcpy.management.CalculateField(intersect_result, 'id_2_source', "'{}'".format(fc_2_name), 'PYTHON3')
-
-
-def fetch_domains(sde_connection_file, in_table):
-    """
-    fetches domains from a table
-    :param sde_connection_file: sde connection file path
-    :param in_table: table to fetch domains from
-    :return: dictionary of domains
-    """
-    all_domains = {d.name: d for d in arcpy.da.ListDomains(sde_connection_file)}
-    domain_dict = {
-        fld.name: {k: v for k, v in all_domains[fld.domain].codedValues.items()}
-        for fld in arcpy.ListFields(in_table) if fld.domain
-    }
-    return domain_dict
-
-
-def format_message(progress, buffer, label):
-    data = {
-        'progress': progress,
-        'buffer': buffer,
-        'label': label
-    }
-    return json.dumps(data)
-
+tools = r"C:\path\to\sweri_utils"
+sys.path.append(tools)
+from intersections import configure_intersection_sources, update_schema_for_intersections_insert
 
 if __name__ == '__main__':
     arcpy.env.overwriteOutput = True
     aoi = arcpy.GetParameterAsText(0) # AOI
-    schema='staging'
-    # schema = arcpy.GetParameterAsText(1)
-    sde_connection_file = 'Z:\\home\\arcgis\\sweri-staging\\sweri-data-tools\\sweri_staging.sde'
+    schema = arcpy.GetParameterAsText(1)
+    sde_connection_file = arcpy.GetParameterAsText(2)
     arcpy.AddMessage('Configuring Data Sources')
     treatment_intersections = path.join(sde_connection_file, 'sweri.{}.intersections'.format(schema))
     target_table = CreateTable(arcpy.env.scratchGDB, 'intersections', template=treatment_intersections)

--- a/gp_tool/aoi_intersections.py
+++ b/gp_tool/aoi_intersections.py
@@ -1,3 +1,5 @@
+import json
+
 import arcpy
 from os import path
 import sys, os
@@ -13,15 +15,71 @@ from arcpy.management import CreateTable
 #                         stderrToServer=True)
 #########################################################map
 
-tools = r"C:\path\to\sweri_utils"
-sys.path.append(tools)
-from intersections import configure_intersection_sources, update_schema_for_intersections_insert
+def configure_intersection_sources(sde_connection_file, schema):
+    """
+    configures intersection sources fetched from intersection source list
+    :param sde_connection_file: sde connection file path
+    :param schema: target schema
+    :return: intersection sources and intersection targets dictionaries
+    """
+    intersect_sources = {}
+    intersect_targets = {}
+    domains = fetch_domains(sde_connection_file,
+                            path.join(sde_connection_file, 'sweri.{}.intersections_source_list'.format(schema)))
+    fields = ['source', 'id_source', 'uid_fields', 'use_as_target', 'source_type', 'name']
+    with arcpy.da.SearchCursor(path.join(sde_connection_file, 'sweri.{}.intersections_source_list'.format(schema)),
+                               field_names=fields, sql_clause=(None, "ORDER BY source_type ASC")) as source_cursor:
+        for r in source_cursor:
+            s = {'source': r[0], 'id': r[2], 'source_type': r[4]}
+            if 'name' in domains and r[5] in domains['name']:
+                s['name'] = domains['name'][r[5]]
+            intersect_sources[r[1]] = s
+            if r[3] == 1:
+                intersect_targets[r[1]] = s
+    return intersect_sources, intersect_targets
+
+
+def update_schema_for_intersections_insert(intersect_result, fc_1_name, fc_2_name):
+    # update existing fields with new id column names
+    arcpy.management.AlterField(intersect_result, 'unique_id', 'id_1', 'id_1')
+    arcpy.management.AlterField(intersect_result, 'unique_id_1', 'id_2', 'id_2')
+    arcpy.management.AlterField(intersect_result, 'feat_source', 'id_1_source', 'id_1_source')
+    arcpy.management.AlterField(intersect_result, 'feat_source_1', 'id_2_source', 'id_2_source')
+    # add field names
+    arcpy.management.CalculateField(intersect_result, 'id_1_source', "'{}'".format(fc_1_name), 'PYTHON3')
+    arcpy.management.CalculateField(intersect_result, 'id_2_source', "'{}'".format(fc_2_name), 'PYTHON3')
+
+
+def fetch_domains(sde_connection_file, in_table):
+    """
+    fetches domains from a table
+    :param sde_connection_file: sde connection file path
+    :param in_table: table to fetch domains from
+    :return: dictionary of domains
+    """
+    all_domains = {d.name: d for d in arcpy.da.ListDomains(sde_connection_file)}
+    domain_dict = {
+        fld.name: {k: v for k, v in all_domains[fld.domain].codedValues.items()}
+        for fld in arcpy.ListFields(in_table) if fld.domain
+    }
+    return domain_dict
+
+
+def format_message(progress, buffer, label):
+    data = {
+        'progress': progress,
+        'buffer': buffer,
+        'label': label
+    }
+    return json.dumps(data)
+
 
 if __name__ == '__main__':
     arcpy.env.overwriteOutput = True
     aoi = arcpy.GetParameterAsText(0) # AOI
-    schema = arcpy.GetParameterAsText(1)
-    sde_connection_file = arcpy.GetParameterAsText(2)
+    schema='staging'
+    # schema = arcpy.GetParameterAsText(1)
+    sde_connection_file = 'Z:\\home\\arcgis\\sweri-staging\\sweri-data-tools\\sweri_staging.sde'
     arcpy.AddMessage('Configuring Data Sources')
     treatment_intersections = path.join(sde_connection_file, 'sweri.{}.intersections'.format(schema))
     target_table = CreateTable(arcpy.env.scratchGDB, 'intersections', template=treatment_intersections)

--- a/intersections.py
+++ b/intersections.py
@@ -201,10 +201,9 @@ def setup_intersection_features_table_and_remove_old_features(docker_db_cursor, 
 
 def calculate_intersections_and_swap_tables(docker_db_cursor, docker_schema, intersect_sources, intersect_targets):
     # setup table
-    configure_new_intersections_table(docker_db_cursor, docker_schema)
+    # configure_new_intersections_table(docker_db_cursor, docker_schema)
     # calculate intersections
-    calculate_intersections_from_sources(intersect_sources, intersect_targets, 'new_intersections', docker_db_cursor,
-                                         docker_schema)
+    #calculate_intersections_from_sources(intersect_sources, intersect_targets, 'new_intersections', docker_db_cursor, docker_schema)
     # create the template for the new intersect
     rotate_tables(docker_db_cursor, docker_schema, 'intersections', 'intersections_backup', 'new_intersections',
                   drop_temp=True)
@@ -213,21 +212,21 @@ def run_intersections(docker_db_cursor, docker_conn, docker_schema, rds_db_curso
     ############## setting intersection sources ################
     intersections = fetch_features(f'{intersection_source_list_url}/0/query',
                                    {'f': 'json', 'where': '1=1', 'outFields': '*', 'orderByFields': 'source_type ASC'})
-    # handle coded value domains
+    # # handle coded value domains
     cvs = create_coded_val_dict(intersection_src_url, 0)
     intersect_sources, intersect_targets = configure_intersection_sources(intersections, cvs, script_start)
-
-    ############## setting up intersection features ################
-    setup_intersection_features_table_and_remove_old_features(docker_db_cursor, docker_schema, intersect_sources)
-    ############## fetching features ################
-    # get latest features based on source
-    fetch_features_to_intersect(intersect_sources, docker_db_cursor, docker_schema, 'intersection_features',
-                                rds_db_cursor, rds_schema, wkid)
-    # refresh the spatial index
-    refresh_spatial_index(docker_db_cursor, docker_schema, 'intersection_features')
-
-    # run VACUUM ANALYZE to increase performance after bulk updates
-    run_vacuum_analyze(docker_conn, docker_db_cursor, docker_schema, 'intersection_features')
+    #
+    # ############## setting up intersection features ################
+    # setup_intersection_features_table_and_remove_old_features(docker_db_cursor, docker_schema, intersect_sources)
+    # ############## fetching features ################
+    # # get latest features based on source
+    # fetch_features_to_intersect(intersect_sources, docker_db_cursor, docker_schema, 'intersection_features',
+    #                             rds_db_cursor, rds_schema, wkid)
+    # # refresh the spatial index
+    # refresh_spatial_index(docker_db_cursor, docker_schema, 'intersection_features')
+    #
+    # # run VACUUM ANALYZE to increase performance after bulk updates
+    # run_vacuum_analyze(docker_conn, docker_db_cursor, docker_schema, 'intersection_features')
     ############## calculating intersections ################
     calculate_intersections_and_swap_tables(docker_db_cursor, docker_schema, intersect_sources, intersect_targets)
 

--- a/intersections.py
+++ b/intersections.py
@@ -104,7 +104,7 @@ def calculate_intersections_and_insert(cursor, schema, insert_table, source_key,
          b.unique_id as id_2, 
          b.feat_source as id_2_source
          from {schema}.intersection_features a, {schema}.intersection_features b
-         where ST_INTERSECTS (a.shape, b.shape) 
+         where ST_IsValid(a.shape) and ST_IsValid(b.shape) and ST_INTERSECTS (a.shape, b.shape)  
          and a.feat_source = '{source_key}'
          and b.feat_source = '{target_key}';"""
     cursor.execute('BEGIN;')
@@ -130,7 +130,7 @@ def insert_feature_into_db(cursor, target_table, feature, fc_name, id_field):
         raise KeyError(f'missing or incorrect id field: {id_field}')
 
     json_geom = json.dumps(feature['geometry'])
-    q = f"INSERT INTO {target_table} (unique_id, feat_source, shape) VALUES ('{feature['properties'][id_field]}', '{fc_name}',ST_Transform(ST_SetSRID(ST_MakeValid(ST_GeomFromGeoJSON('{json_geom}')), 4326), 3857));"
+    q = f"INSERT INTO {target_table} (unique_id, feat_source, shape) VALUES ('{feature['properties'][id_field]}', '{fc_name}',ST_MakeValid(ST_Transform(ST_SetSRID(ST_GeomFromGeoJSON('{json_geom}'), 4326), 3857)));"
     try:
         cursor.execute('BEGIN;')
         cursor.execute(q)

--- a/intersections.py
+++ b/intersections.py
@@ -269,9 +269,9 @@ def update_intersection_features_rds_db(docker_cursor, docker_schema, rds_cursor
     # we do not use the object id column in docker, but it is required in the rds db
     docker_cursor.execute('BEGIN;')
     docker_cursor.execute(f'''
-        INSERT INTO {docker_schema}.intersection_features (objectid)
-        SELECT row_number() OVER () AS objectid
-        FROM {docker_schema}.intersection_features;
+        DROP SEQUENCE IF EXISTS intersection_features_objectid_seq;
+        CREATE SEQUENCE intersection_features_objectid_seq START 1;
+        UPDATE {docker_schema}.intersection_features set objectid = nextval('intersection_features_objectid_seq')
     ''')
     docker_cursor.execute('COMMIT;')
 

--- a/intersections.py
+++ b/intersections.py
@@ -10,6 +10,7 @@ from sweri_utils.s3 import import_s3_csv_to_postgres_table
 from sweri_utils.sql import connect_to_pg_db, rename_postgres_table, insert_from_db, refresh_spatial_index, \
     rotate_tables, copy_table_across_servers, delete_from_table, run_vacuum_analyze
 import watchtower
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s', encoding='utf-8', level=logging.INFO,
                     datefmt='%Y-%m-%d %H:%M:%S')
@@ -129,7 +130,7 @@ def insert_feature_into_db(cursor, target_table, feature, fc_name, id_field):
         raise KeyError(f'missing or incorrect id field: {id_field}')
 
     json_geom = json.dumps(feature['geometry'])
-    q = f"INSERT INTO {target_table} (unique_id, feat_source, shape) VALUES ('{feature['properties'][id_field]}', '{fc_name}',ST_SetSRID(ST_MakeValid(ST_GeomFromGeoJSON('{json_geom}')), 4326));"
+    q = f"INSERT INTO {target_table} (unique_id, feat_source, shape) VALUES ('{feature['properties'][id_field]}', '{fc_name}',ST_Transform(ST_SetSRID(ST_MakeValid(ST_GeomFromGeoJSON('{json_geom}')), 4326), 3857));"
     try:
         cursor.execute('BEGIN;')
         cursor.execute(q)
@@ -192,6 +193,7 @@ def fetch_features_to_intersect(intersect_sources, docker_cursor, docker_schema,
         else:
             raise ValueError('invalid source type: {}'.format(value['source_type']))
 
+
 def setup_intersection_features_table_and_remove_old_features(docker_db_cursor, docker_schema, intersect_sources):
     # setup intersection features table
     configure_intersection_features_table(docker_db_cursor, docker_schema)
@@ -199,56 +201,16 @@ def setup_intersection_features_table_and_remove_old_features(docker_db_cursor, 
     for src in intersect_sources.keys():
         delete_from_table(docker_db_cursor, docker_schema, 'intersection_features', f"feat_source = '{src}'")
 
+
 def calculate_intersections_and_swap_tables(docker_db_cursor, docker_schema, intersect_sources, intersect_targets):
     # setup table
-    # configure_new_intersections_table(docker_db_cursor, docker_schema)
+    configure_new_intersections_table(docker_db_cursor, docker_schema)
     # calculate intersections
-    #calculate_intersections_from_sources(intersect_sources, intersect_targets, 'new_intersections', docker_db_cursor, docker_schema)
+    calculate_intersections_from_sources(intersect_sources, intersect_targets, 'new_intersections', docker_db_cursor,
+                                         docker_schema)
     # create the template for the new intersect
     rotate_tables(docker_db_cursor, docker_schema, 'intersections', 'intersections_backup', 'new_intersections',
                   drop_temp=True)
-
-def run_intersections(docker_db_cursor, docker_conn, docker_schema, rds_db_cursor, rds_db_conn, rds_schema, s3_bucket, start, wkid, intersection_source_list_url):
-    ############## setting intersection sources ################
-    # intersections = fetch_features(f'{intersection_source_list_url}/0/query',
-    #                                {'f': 'json', 'where': '1=1', 'outFields': '*', 'orderByFields': 'source_type ASC'})
-    # # # handle coded value domains
-    # cvs = create_coded_val_dict(intersection_src_url, 0)
-    # intersect_sources, intersect_targets = configure_intersection_sources(intersections, cvs, script_start)
-    #
-    # ############## setting up intersection features ################
-    # setup_intersection_features_table_and_remove_old_features(docker_db_cursor, docker_schema, intersect_sources)
-    # ############## fetching features ################
-    # # get latest features based on source
-    # fetch_features_to_intersect(intersect_sources, docker_db_cursor, docker_schema, 'intersection_features',
-    #                             rds_db_cursor, rds_schema, wkid)
-    # # refresh the spatial index
-    # refresh_spatial_index(docker_db_cursor, docker_schema, 'intersection_features')
-    #
-    # # run VACUUM ANALYZE to increase performance after bulk updates
-    # run_vacuum_analyze(docker_conn, docker_db_cursor, docker_schema, 'intersection_features')
-    ############## calculating intersections ################
-    #calculate_intersections_and_swap_tables(docker_db_cursor, docker_schema, intersect_sources, intersect_targets)
-
-    ############## update run info on intersection sources table ################
-    #update_last_run(intersections, start, intersection_src_url, 0)
-
-    ############## write to csv and upload to s3 ################
-    #logger.info('uploading csv to s3')
-    #create_csv_and_upload_to_s3(docker_db_cursor, docker_schema, 'intersections',
-    #                             ['id_1', 'id_2', 'id_1_source', 'id_2_source', 'acre_overlap'],
-    #                             f'intersections_{docker_schema}.csv', s3_bucket)
-    # logger.info('completed upload to s3')
-    #
-    # # upload intersections to rds
-    # update_intersections_rds_db(rds_db_cursor, rds_db_conn, rds_schema, s3_bucket)
-    # upload intersection features to rds
-    update_intersection_features_rds_db(docker_db_cursor, docker_schema, rds_db_cursor, rds_schema)
-
-    #close connections
-    docker_conn.close()
-    rds_db_conn.close()
-
 
 
 def update_intersections_rds_db(rds_cursor, rds_conn, rds_schema, s3_bucket):
@@ -267,19 +229,68 @@ def update_intersections_rds_db(rds_cursor, rds_conn, rds_schema, s3_bucket):
 
 def update_intersection_features_rds_db(docker_cursor, docker_schema, rds_cursor, rds_schema):
     # we do not use the object id column in docker, but it is required in the rds db
-    docker_cursor.execute('BEGIN;')
-    docker_cursor.execute(f'''
-        DROP SEQUENCE IF EXISTS intersection_features_objectid_seq;
-        CREATE SEQUENCE intersection_features_objectid_seq START 1;
-        UPDATE {docker_schema}.intersection_features set objectid = nextval('intersection_features_objectid_seq')
-    ''')
-    docker_cursor.execute('COMMIT;')
-
-    copy_table_across_servers(docker_cursor, docker_schema, 'intersection_features', rds_cursor, rds_schema,'intersection_features_dump')
+    create_intersection_features_objectid(docker_cursor, docker_schema)
+    copy_table_across_servers(docker_cursor, docker_schema, 'intersection_features', rds_cursor, rds_schema,
+                              'intersection_features_dump')
     logger.info('importing intersection_features csv into postgres')
     # swap the tables in the rds db
     logger.info('swapping tables')
-    rotate_tables(rds_cursor, rds_schema, 'intersection_features', 'intersection_features_backup', 'intersection_features_dump',drop_temp=False)
+    rotate_tables(rds_cursor, rds_schema, 'intersection_features', 'intersection_features_backup',
+                  'intersection_features_dump', drop_temp=False)
+
+
+def create_intersection_features_objectid(docker_cursor, docker_schema):
+    docker_cursor.execute('BEGIN;')
+    docker_cursor.execute(f'''
+            DROP SEQUENCE IF EXISTS intersection_features_objectid_seq;
+            CREATE SEQUENCE intersection_features_objectid_seq START 1;
+            UPDATE {docker_schema}.intersection_features set objectid = nextval('intersection_features_objectid_seq')
+        ''')
+    docker_cursor.execute('COMMIT;')
+
+
+def run_intersections(docker_db_cursor, docker_conn, docker_schema, rds_db_cursor, rds_db_conn, rds_schema, s3_bucket,
+                      start, wkid, intersection_source_list_url):
+    ############## setting intersection sources ################
+    intersections = fetch_features(f'{intersection_source_list_url}/0/query',
+                                   {'f': 'json', 'where': '1=1', 'outFields': '*', 'orderByFields': 'source_type ASC'})
+    # handle coded value domains
+    cvs = create_coded_val_dict(intersection_src_url, 0)
+    intersect_sources, intersect_targets = configure_intersection_sources(intersections, cvs, script_start)
+    #
+    # ############## setting up intersection features ################
+    setup_intersection_features_table_and_remove_old_features(docker_db_cursor, docker_schema, intersect_sources)
+    ############## fetching features ################
+    # get latest features based on source
+    fetch_features_to_intersect(intersect_sources, docker_db_cursor, docker_schema, 'intersection_features',
+                                rds_db_cursor, rds_schema, wkid)
+    # refresh the spatial index
+    refresh_spatial_index(docker_db_cursor, docker_schema, 'intersection_features')
+
+    # run VACUUM ANALYZE to increase performance after bulk updates
+    run_vacuum_analyze(docker_conn, docker_db_cursor, docker_schema, 'intersection_features')
+    ############## calculating intersections ################
+    calculate_intersections_and_swap_tables(docker_db_cursor, docker_schema, intersect_sources, intersect_targets)
+
+    ############## update run info on intersection sources table ################
+    update_last_run(intersections, start, intersection_src_url, 0)
+
+    ############## write to csv and upload to s3 ################
+    logger.info('uploading csv to s3')
+    create_csv_and_upload_to_s3(docker_db_cursor, docker_schema, 'intersections',
+                                ['id_1', 'id_2', 'id_1_source', 'id_2_source', 'acre_overlap'],
+                                f'intersections_{docker_schema}.csv', s3_bucket)
+    logger.info('completed upload to s3')
+
+    # upload intersections to rds
+    update_intersections_rds_db(rds_db_cursor, rds_db_conn, rds_schema, s3_bucket)
+
+    # upload intersection features to rds
+    update_intersection_features_rds_db(docker_db_cursor, docker_schema, rds_db_cursor, rds_schema)
+
+    # close connections
+    docker_conn.close()
+    rds_db_conn.close()
 
 
 if __name__ == '__main__':
@@ -314,6 +325,7 @@ if __name__ == '__main__':
 
     ############## intersections processing in docker ################
     # function that runs everything for creating new intersections in docker, uploading the results to s3, and swapping the tables on the rds instance
-    run_intersections(docker_pg_cursor, docker_pg_conn, docker_db_schema, rds_pg_cursor, rds_pg_conn, rds_db_schema, s3_bucket_name,
+    run_intersections(docker_pg_cursor, docker_pg_conn, docker_db_schema, rds_pg_cursor, rds_pg_conn, rds_db_schema,
+                      s3_bucket_name,
                       script_start, sr_wkid, intersection_src_url)
     logger.info('completed intersection processing')

--- a/intersections.py
+++ b/intersections.py
@@ -267,7 +267,7 @@ def update_intersections_rds_db(rds_cursor, rds_conn, rds_schema, s3_bucket):
 
 def update_intersection_features_rds_db(docker_cursor, docker_schema, rds_cursor, rds_schema):
     copy_table_across_servers(docker_cursor, docker_schema, 'intersection_features', rds_cursor, rds_schema,'intersection_features_dump',
-                              [f"sde.next_rowid({rds_schema}, 'intersection_features_dump')",'unique_id', 'feat_source', 'gdb_geomattr_data','shape'])
+                              [f"sde.next_rowid('{rds_schema}', 'intersection_features_dump')",'unique_id', 'feat_source', 'gdb_geomattr_data','shape'])
     logger.info('importing intersection_features csv into postgres')
     # swap the tables in the rds db
     logger.info('swapping tables')

--- a/sweri_utils/download.py
+++ b/sweri_utils/download.py
@@ -152,7 +152,7 @@ def get_all_features(url, ids, out_sr=3857, out_fields=None, chunk_size=2000, fo
             if id_list == '':
                 break
             # query params
-            params = {'f': format, 'outSR': out_sr, 'outFields': ','.join(out_fields), 'returnGeometry': 'true',
+            params = {'f': format, 'outSR': 4326 if format == 'geojson' else out_sr, 'outFields': ','.join(out_fields), 'returnGeometry': 'true',
                       'objectIds': id_list}
 
             start += chunk_size

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -162,11 +162,9 @@ def drop_temp_table(cursor: psycopg.Cursor, schema: str, backup_table_name: str)
 
 
 def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, from_table: str, to_cursor: psycopg.Cursor,
-                              to_schema: str, to_table: str, fields = None) -> None:
+                              to_schema: str, to_table: str) -> None:
     """
     Copies a table from one PostgreSQL server to another.
-
-    :param fields:
     :param from_cursor: The cursor for the source database.
     :param from_schema: The schema of the source table.
     :param from_table: The name of the source table.
@@ -178,10 +176,7 @@ def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, fro
     logging.info(f'copying {from_schema}.{from_table} from out cursor to {to_schema}.{to_table} via in-cursor')
     with from_cursor.copy(f"COPY (SELECT * FROM {from_schema}.{from_table}) TO STDOUT (FORMAT BINARY)") as out_copy:
         to_cursor.execute(f"DELETE FROM {to_schema}.{to_table};")
-        q = f"COPY {to_schema}.{to_table} FROM STDIN (FORMAT BINARY)"
-        if fields:
-            q = f"COPY {to_schema}.{to_table} ({','.join(fields)}) FROM STDIN (FORMAT BINARY)"
-        with to_cursor.copy(q) as in_copy:
+        with to_cursor.copy(f"COPY {to_schema}.{to_table} FROM STDIN (FORMAT BINARY)") as in_copy:
             for data in out_copy:
                 in_copy.write(data)
     logging.info(f'copied {from_schema}.{from_table} from out cursor to {to_schema}.{to_table} via in-cursor')

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -172,9 +172,9 @@ def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, fro
     :return: None
     """
     logging.info(f'copying {from_schema}.{from_table} from out cursor to {to_schema}.{to_table} via in-cursor')
-    with from_cursor.copy(f"COPY (SELECT * FROM {from_schema}.{from_table}) TO STDOUT (FORMAT BINARY)") as out_copy:
+    with from_cursor.copy(f"COPY (SELECT * FROM {from_schema}.{from_table}) TO STDOUT") as out_copy:
         to_cursor.execute(f"DELETE FROM {to_schema}.{to_table};")
-        with to_cursor.copy(f"COPY {to_schema}.{to_table} FROM STDIN (FORMAT BINARY)") as in_copy:
+        with to_cursor.copy(f"COPY {to_schema}.{to_table} FROM STDIN") as in_copy:
             for data in out_copy:
                 in_copy.write(data)
     logging.info(f'copied {from_schema}.{from_table} from out cursor to {to_schema}.{to_table} via in-cursor')

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -48,10 +48,12 @@ def insert_from_db(
         from_table: str,
         from_fields: list[str],
         from_shape: str = 'shape',
-        to_shape: str = 'shape'
+        to_shape: str = 'shape',
+        wkid = 3857
 ) -> None:
     """
     Inserts records from one database into another in an enterprise geodatabase
+    :param wkid:
     :param to_shape:
     :param from_shape:
     :param cursor: psycopg2 connection cursor object
@@ -62,7 +64,7 @@ def insert_from_db(
     :param from_fields: list of field names mapping to insert fields
     :return: None
     """
-    q = f'''insert into {schema}.{insert_table} ({to_shape}, {','.join(insert_fields)}) select ST_TRANSFORM(ST_MakeValid({from_shape}), 4326), {','.join(from_fields)} from {schema}.{from_table};'''
+    q = f'''insert into {schema}.{insert_table} ({to_shape}, {','.join(insert_fields)}) select ST_TRANSFORM(ST_MakeValid({from_shape}), {wkid}), {','.join(from_fields)} from {schema}.{from_table};'''
     logging.info(q)
     cursor.execute('BEGIN;')
     cursor.execute(q)

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -162,10 +162,11 @@ def drop_temp_table(cursor: psycopg.Cursor, schema: str, backup_table_name: str)
 
 
 def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, from_table: str, to_cursor: psycopg.Cursor,
-                              to_schema: str, to_table: str) -> None:
+                              to_schema: str, to_table: str, fields = None) -> None:
     """
     Copies a table from one PostgreSQL server to another.
 
+    :param fields:
     :param from_cursor: The cursor for the source database.
     :param from_schema: The schema of the source table.
     :param from_table: The name of the source table.
@@ -177,7 +178,10 @@ def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, fro
     logging.info(f'copying {from_schema}.{from_table} from out cursor to {to_schema}.{to_table} via in-cursor')
     with from_cursor.copy(f"COPY (SELECT * FROM {from_schema}.{from_table}) TO STDOUT (FORMAT BINARY)") as out_copy:
         to_cursor.execute(f"DELETE FROM {to_schema}.{to_table};")
-        with to_cursor.copy(f"COPY {to_schema}.{to_table} FROM STDIN (FORMAT BINARY)") as in_copy:
+        q = f"COPY {to_schema}.{to_table} FROM STDIN (FORMAT BINARY)"
+        if fields:
+            q = f"COPY {to_schema}.{to_table} ({','.join(fields)}) FROM STDIN (FORMAT BINARY)"
+        with to_cursor.copy(q) as in_copy:
             for data in out_copy:
                 in_copy.write(data)
     logging.info(f'copied {from_schema}.{from_table} from out cursor to {to_schema}.{to_table} via in-cursor')

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -95,8 +95,6 @@ def refresh_spatial_index(cursor: psycopg.Cursor, schema: str, table: str) -> No
     """
     Refreshes the spatial index on a specified table in a PostgreSQL database.
 
-    This function drops the existing spatial index (if any) and recreates it.
-
     :param cursor: The database cursor to execute the SQL commands.
     :param schema: The schema where the table is located.
     :param table: The name of the table for which the spatial index will be refreshed.
@@ -104,9 +102,7 @@ def refresh_spatial_index(cursor: psycopg.Cursor, schema: str, table: str) -> No
     """
     logging.info(f'refreshing spatial index on {schema}.{table}')
     cursor.execute('BEGIN;')
-    cursor.execute(f'DROP INDEX IF EXISTS {table}_shape_idx;')
-    # recreate index
-    cursor.execute(f'CREATE INDEX {table}_shape_idx ON {schema}.{table} USING GIST (shape);')
+    cursor.execute(f'CREATE INDEX ON {schema}.{table} USING GIST (shape);')
     cursor.execute('COMMIT;')
     logging.info(f'refreshed spatial index on {schema}.{table}')
 
@@ -206,3 +202,9 @@ def run_vacuum_analyze(connection, cursor, schema, table):
     connection.autocommit = True
     cursor.execute(f'VACUUM ANALYZE {schema}.{table};')
     connection.autocommit = False
+
+
+def postgres_create_index(cursor, schema, table_name, column_to_index):
+    cursor.execute('BEGIN;')
+    cursor.execute(f'CREATE INDEX ON {schema}.{table_name} ({column_to_index});')
+    cursor.execute('COMMIT;')

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -64,7 +64,7 @@ def insert_from_db(
     :param from_fields: list of field names mapping to insert fields
     :return: None
     """
-    q = f'''insert into {schema}.{insert_table} ({to_shape}, {','.join(insert_fields)}) select ST_TRANSFORM(ST_MakeValid({from_shape}), {wkid}), {','.join(from_fields)} from {schema}.{from_table};'''
+    q = f'''insert into {schema}.{insert_table} ({to_shape}, {','.join(insert_fields)}) select ST_MakeValid(ST_TRANSFORM({from_shape}, {wkid})), {','.join(from_fields)} from {schema}.{from_table};'''
     logging.info(q)
     cursor.execute('BEGIN;')
     cursor.execute(q)

--- a/sweri_utils/sql.py
+++ b/sweri_utils/sql.py
@@ -13,22 +13,22 @@ def rename_postgres_table(cursor: psycopg.Cursor, schema: str, old_table_name: s
     :param new_table_name: The new name for the table.
     :return: None
     """
-    cursor.execute(f'BEGIN;')
+    cursor.execute('BEGIN;')
     cursor.execute(f'ALTER TABLE {schema}.{old_table_name} RENAME TO {new_table_name};')
-    cursor.execute(f'COMMIT;')
+    cursor.execute('COMMIT;')
 
 
 def connect_to_pg_db(db_host: str, db_port: int, db_name: str, db_user: str, db_password: str) -> tuple:
     """
-     Establishes a connection to a PostgreSQL database using the provided credentials.
+    Establishes a connection to a PostgreSQL database using the provided credentials.
 
-     :param db_host: The hostname of the PostgreSQL server.
-     :param db_port: The port number on which the PostgreSQL server is listening.
-     :param db_name: The name of the database to connect to.
-     :param db_user: The username to use for authentication.
-     :param db_password: The password to use for authentication.
-     :return: A tuple containing the database cursor and connection objects.
-     """
+    :param db_host: The hostname of the PostgreSQL server.
+    :param db_port: The port number on which the PostgreSQL server is listening.
+    :param db_name: The name of the database to connect to.
+    :param db_user: The username to use for authentication.
+    :param db_password: The password to use for authentication.
+    :return: A tuple containing the database cursor and connection objects.
+    """
     conn = psycopg.connect(
         host=db_host,
         port=db_port,
@@ -49,27 +49,30 @@ def insert_from_db(
         from_fields: list[str],
         from_shape: str = 'shape',
         to_shape: str = 'shape',
-        wkid = 3857
+        wkid: int = 3857
 ) -> None:
     """
-    Inserts records from one database into another in an enterprise geodatabase
-    :param wkid:
-    :param to_shape:
-    :param from_shape:
-    :param cursor: psycopg2 connection cursor object
-    :param schema: schema to use
-    :param insert_table: table to insert features into
-    :param insert_fields: list of insert fields for target table
-    :param from_table: table to insert features from
-    :param from_fields: list of field names mapping to insert fields
+    Inserts records from one table into another in a PostgreSQL database.
+
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the tables are located.
+    :param insert_table: The name of the table to insert records into.
+    :param insert_fields: A list of field names to insert into the target table.
+    :param from_table: The name of the table to copy records from.
+    :param from_fields: A list of field names to copy from the source table.
+    :param from_shape: The geometry column in the source table.
+    :param to_shape: The geometry column in the target table.
+    :param wkid: The spatial reference ID to use for the geometry transformation.
     :return: None
     """
-    q = f'''insert into {schema}.{insert_table} ({to_shape}, {','.join(insert_fields)}) select ST_MakeValid(ST_TRANSFORM({from_shape}, {wkid})), {','.join(from_fields)} from {schema}.{from_table};'''
+    q = f'''INSERT INTO {schema}.{insert_table} ({to_shape}, {','.join(insert_fields)}) 
+            SELECT ST_MakeValid(ST_TRANSFORM({from_shape}, {wkid})), {','.join(from_fields)} 
+            FROM {schema}.{from_table};'''
     logging.info(q)
     cursor.execute('BEGIN;')
     cursor.execute(q)
     cursor.execute('COMMIT;')
-    logging.info(f'completed {q}')
+    logging.info(f'Completed {q}')
 
 
 def pg_copy_to_csv(cursor: psycopg.Cursor, schema: str, table: str, filename: str, columns: list[str]) -> TextIO:
@@ -100,11 +103,11 @@ def refresh_spatial_index(cursor: psycopg.Cursor, schema: str, table: str) -> No
     :param table: The name of the table for which the spatial index will be refreshed.
     :return: None
     """
-    logging.info(f'refreshing spatial index on {schema}.{table}')
+    logging.info(f'Refreshing spatial index on {schema}.{table}')
     cursor.execute('BEGIN;')
     cursor.execute(f'CREATE INDEX ON {schema}.{table} USING GIST (shape);')
     cursor.execute('COMMIT;')
-    logging.info(f'refreshed spatial index on {schema}.{table}')
+    logging.info(f'Refreshed spatial index on {schema}.{table}')
 
 
 def rotate_tables(cursor: psycopg.Cursor, schema: str, main_table_name: str, backup_table_name: str,
@@ -126,66 +129,79 @@ def rotate_tables(cursor: psycopg.Cursor, schema: str, main_table_name: str, bac
     :param drop_temp: If True, the temporary table will be dropped. If False, it will be renamed to the new table.
     :return: None
     """
-    logging.info('moving to postgres table updates')
-    # rename backup  to temp table to make space for new backup
-    # drop temp backup table
+    logging.info('Moving to PostgreSQL table updates')
     drop_temp_table(cursor, schema, backup_table_name)
 
-    rename_postgres_table(cursor, schema, backup_table_name,
-                          f'{backup_table_name}_temp')
+    rename_postgres_table(cursor, schema, backup_table_name, f'{backup_table_name}_temp')
     logging.info(f'{schema}.{backup_table_name} renamed to {schema}.{backup_table_name}_temp')
 
-    # rename current table to backup table
     rename_postgres_table(cursor, schema, main_table_name, backup_table_name)
     logging.info(f'{schema}.{main_table_name} renamed to {schema}.{backup_table_name}')
 
-    # rename new intersections table to new data
     rename_postgres_table(cursor, schema, new_table_name, main_table_name)
     logging.info(f'{schema}.{new_table_name} renamed to {schema}.{main_table_name}')
 
-    # drop (default) or swap out temp table with new table
     if drop_temp:
         drop_temp_table(cursor, schema, backup_table_name)
     else:
-        # cycle temp backup into new table
         rename_postgres_table(cursor, schema, f'{backup_table_name}_temp', new_table_name)
         logging.info(f'{schema}.{backup_table_name}_temp renamed to {schema}.{new_table_name}')
 
+
 def drop_temp_table(cursor: psycopg.Cursor, schema: str, backup_table_name: str) -> None:
-    # drop temp backup table
+    """
+    Drops a temporary backup table in a PostgreSQL database.
+
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the table is located.
+    :param backup_table_name: The name of the backup table to be dropped.
+    :return: None
+    """
     cursor.execute('BEGIN;')
     cursor.execute(f'DROP TABLE IF EXISTS {schema}.{backup_table_name}_temp CASCADE;')
     cursor.execute('COMMIT;')
     logging.info(f'{schema}.{backup_table_name}_temp deleted')
 
-def fetch_and_order_columns(cursor, schema, table):
+
+def fetch_and_order_columns(cursor: psycopg.Cursor, schema: str, table: str) -> list[str]:
+    """
+    Fetches and orders the columns of a specified table in a PostgreSQL database.
+
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the table is located.
+    :param table: The name of the table to fetch columns from.
+    :return: A list of column names ordered alphabetically.
+    """
     columns_query = f"SELECT column_name FROM information_schema.columns WHERE table_schema = '{schema}' AND table_name = '{table}'"
     cursor.execute(columns_query)
     columns = [row[0] for row in cursor.fetchall()]
     columns.sort()
     return columns
 
+
 def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, from_table: str, to_cursor: psycopg.Cursor,
-                              to_schema: str, to_table: str, from_columns: list[str], to_columns: list[str], delete_to_rows = False) -> None:
+                              to_schema: str, to_table: str, from_columns: list[str], to_columns: list[str], delete_to_rows: bool = False) -> None:
     """
     Copies a table from one PostgreSQL server to another.
+
     :param from_cursor: The cursor for the source database.
     :param from_schema: The schema of the source table.
     :param from_table: The name of the source table.
     :param to_cursor: The cursor for the destination database.
     :param to_schema: The schema of the destination table.
     :param to_table: The name of the destination table.
+    :param from_columns: A list of column names to copy from the source table.
+    :param to_columns: A list of column names to copy to the destination table.
+    :param delete_to_rows: If True, deletes all rows in the destination table before copying.
     :return: None
     """
-
     from_copy = f"COPY (SELECT {','.join(from_columns)} FROM {from_schema}.{from_table}) TO STDOUT"
-    logging.info(f'running {from_copy}')
+    logging.info(f'Running {from_copy}')
 
     with from_cursor.copy(from_copy) as out_copy:
-        # optionally
         if delete_to_rows:
             delete_q = f"DELETE FROM {to_schema}.{to_table}"
-            logging.warning(f'deleting all features from {to_schema}.{to_table}')
+            logging.warning(f'Deleting all features from {to_schema}.{to_table}')
             to_cursor.execute(delete_q)
         to_copy = f"COPY {to_schema}.{to_table} ({','.join(to_columns)}) FROM STDIN"
         to_cursor.execute('BEGIN;')
@@ -194,35 +210,68 @@ def copy_table_across_servers(from_cursor: psycopg.Cursor, from_schema: str, fro
                 in_copy.write(data)
         to_cursor.execute('COMMIT;')
 
-
-    logging.info(f'copied {from_schema}.{from_table} ({to_columns}) from out cursor to {to_schema}.{to_table} via in-cursor')
+    logging.info(f'Copied {from_schema}.{from_table} ({to_columns}) from out cursor to {to_schema}.{to_table} via in-cursor')
 
 
 def delete_from_table(cursor: psycopg.Cursor, schema: str, table: str, where: str) -> None:
     """
-      Deletes records from a specified table in a PostgreSQL database based on a condition.
+    Deletes records from a specified table in a PostgreSQL database based on a condition.
 
-      :param cursor: The database cursor to execute the SQL commands.
-      :param schema: The schema where the table is located.
-      :param table: The name of the table from which records will be deleted.
-      :param where: The condition to specify which records to delete.
-      :return: None
-      """
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the table is located.
+    :param table: The name of the table from which records will be deleted.
+    :param where: The condition to specify which records to delete.
+    :return: None
+    """
     delete_feat_q = f"DELETE FROM {schema}.{table} WHERE {where};"
-    logging.info(f'running {delete_feat_q}')
+    logging.info(f'Running {delete_feat_q}')
     cursor.execute('BEGIN;')
     cursor.execute(delete_feat_q)
     cursor.execute('COMMIT;')
-    logging.info(f'deleted from {schema}.{table} where {where}')
+    logging.info(f'Deleted from {schema}.{table} where {where}')
 
 
-def run_vacuum_analyze(connection, cursor, schema, table):
+def run_vacuum_analyze(connection: psycopg.Connection, cursor: psycopg.Cursor, schema: str, table: str) -> None:
+    """
+    Runs VACUUM ANALYZE on a specified table in a PostgreSQL database to optimize performance.
+
+    :param connection: The database connection object.
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the table is located.
+    :param table: The name of the table to be vacuumed and analyzed.
+    :return: None
+    """
     connection.autocommit = True
     cursor.execute(f'VACUUM ANALYZE {schema}.{table};')
     connection.autocommit = False
 
 
-def postgres_create_index(cursor, schema, table_name, column_to_index):
+def postgres_create_index(cursor: psycopg.Cursor, schema: str, table_name: str, column_to_index: str) -> None:
+    """
+    Creates an index on a specified column in a PostgreSQL table.
+
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the table is located.
+    :param table_name: The name of the table to create the index on.
+    :param column_to_index: The name of the column to create the index on.
+    :return: None
+    """
     cursor.execute('BEGIN;')
     cursor.execute(f'CREATE INDEX ON {schema}.{table_name} ({column_to_index});')
     cursor.execute('COMMIT;')
+
+def calculate_index_for_fields(cursor: psycopg.Cursor, schema: str, table: str, fields: list[str], spatial = False) -> None:
+    """
+    Calculates the index for specified fields in a PostgreSQL table.
+
+    :param cursor: The database cursor to execute the SQL commands.
+    :param schema: The schema where the table is located.
+    :param table: The name of the table to calculate the index for.
+    :param fields: A list of field names to calculate the index for.
+    :param spatial: Boolean indicating whether to refresh spatial index.
+    :return: None
+    """
+    for field in fields:
+        postgres_create_index(cursor, schema, table, field)
+    if spatial:
+        refresh_spatial_index(cursor, schema, table)

--- a/sweri_utils/tests.py
+++ b/sweri_utils/tests.py
@@ -101,8 +101,8 @@ class DownloadTests(TestCase):
     @patch('arcpy.management.DefineProjection')
     def test_fetch_create_new_fc(self, mock_project, mock_json_to_fc, mock_exists):
         with patch('sweri_utils.download.get_ids') as get_ids_mock, patch(
-            'sweri_utils.download.get_all_features') as get_feat_mock, patch(
-                'sweri_utils.download.get_fields') as get_fields_mock:
+                'sweri_utils.download.get_all_features') as get_feat_mock, patch(
+            'sweri_utils.download.get_fields') as get_fields_mock:
             url = 'http://test.url'
             where = '1=1'
             geom = {'rings': []}
@@ -184,10 +184,9 @@ class DownloadTests(TestCase):
 
     @patch('arcgis.features.FeatureLayer')
     def test_service_to_postgres(self, fl_mock):
-        with patch('sweri_utils.download.get_ids') as get_ids_mock,patch(
-            'sweri_utils.download.query_by_id_and_save_to_fc') as query_and_save_mock:
-
-            get_ids_mock.return_value = [1,2,3]
+        with patch('sweri_utils.download.get_ids') as get_ids_mock, patch(
+                'sweri_utils.download.query_by_id_and_save_to_fc') as query_and_save_mock:
+            get_ids_mock.return_value = [1, 2, 3]
             query_and_save_mock.return_value = (10, 'out_filepath')
             url = 'http://some.url/'
             where_clause = '1=1'
@@ -199,9 +198,10 @@ class DownloadTests(TestCase):
             sde_file = 'test_sde'
             insert_function = Mock()
             chunk_size = 2
-            expected_pg_path = os.path.join('test_sde','test_db.test_schema.test_table_additions')
+            expected_pg_path = os.path.join('test_sde', 'test_db.test_schema.test_table_additions')
 
-            service_to_postgres(url, where_clause, wkid, database, schema, destination_table, cursor, sde_file, insert_function, chunk_size)
+            service_to_postgres(url, where_clause, wkid, database, schema, destination_table, cursor, sde_file,
+                                insert_function, chunk_size)
 
             cursor.execute.assert_called_once_with(f'TRUNCATE {schema}.{destination_table}')
             get_ids_mock.assert_called_once_with(url, where=where_clause)
@@ -211,7 +211,7 @@ class DownloadTests(TestCase):
             )
             insert_function.assert_has_calls(
                 [call(cursor, schema),
-                call(cursor, schema)]
+                 call(cursor, schema)]
             )
 
     @patch('arcpy.management.GetCount')
@@ -236,11 +236,12 @@ class DownloadTests(TestCase):
 
         self.assertEqual(count, 5)
         self.assertEqual(saved_fc, 'saved_fc_path')
-        fl_mock.query.assert_called_once_with(object_ids=id_list,  out_fields="*", return_geometry=True, out_sr=wkid)
+        fl_mock.query.assert_called_once_with(object_ids=id_list, out_fields="*", return_geometry=True, out_sr=wkid)
         mock_exists.assert_called_once_with(sde_fc_path)
         mock_delete.assert_called_once_with(sde_fc_path)
         mock_query.save.assert_called_once_with(sde_file, out_fc_name)
         mock_get_count.assert_called_once_with('saved_fc_path')
+
 
 class FilesTests(TestCase):
     @patch('zipfile.ZipFile')
@@ -306,24 +307,23 @@ class FilesTests(TestCase):
     @patch('arcpy.management.Project')
     def test_gdb_to_postgres(self, mock_project, mock_exist, mock_delete, mock_fc_gdb):
         with patch('sweri_utils.files.download_file_from_url') as download_file_mock, patch(
-            'sweri_utils.files.extract_and_remove_zip_file') as extract_zip_mock:
+                'sweri_utils.files.extract_and_remove_zip_file') as extract_zip_mock:
             mock_exist.return_value = True
             sde_file = 'fake_sde_connection_file'
             gdb_name = 'test_gdb'
-            gdb_path = os.path.join(os.getcwd(),gdb_name)
+            gdb_path = os.path.join(os.getcwd(), gdb_name)
             projection = arcpy.SpatialReference(3857)
             postgres_table_name = 'test_table'
             schema = 'test_schema'
             postgres_table_location = os.path.join(sde_file, f'sweri.{schema}.{postgres_table_name}')
             fc_name = 'Activity_HazFuelTrt_PL'
 
-            feature_class = os.path.join(gdb_path,fc_name)
+            feature_class = os.path.join(gdb_path, fc_name)
             reprojected_fc = os.path.join(gdb_path, f'{postgres_table_name}')
             url = 'http://test.url'
             zip_file = f'{postgres_table_name}.zip'
 
             gdb_to_postgres(url, gdb_name, projection, fc_name, postgres_table_name, sde_file, schema)
-
 
             download_file_mock.assert_called_once_with(url, zip_file)
             extract_zip_mock.assert_called_once_with(zip_file)
@@ -336,6 +336,7 @@ class FilesTests(TestCase):
                 ]
             )
             mock_fc_gdb.assert_called_once_with(reprojected_fc, sde_file)
+
 
 class ConversionTests(TestCase):
     @patch('arcpy.Describe')
@@ -452,6 +453,7 @@ class ConversionTests(TestCase):
             create_coded_val_dict(url, layer)
         self.assertEqual(str(context.exception), 'missing coded values or incorrect domain type')
 
+
 class SqlTests(TestCase):
     def test_rename_postgres_table(self):
         # Mock the connection object
@@ -553,8 +555,7 @@ class SqlTests(TestCase):
         refresh_spatial_index(cursor, schema, table)
 
         cursor.execute.assert_any_call('BEGIN;')
-        cursor.execute.assert_any_call(f'DROP INDEX IF EXISTS {table}_shape_idx;')
-        cursor.execute.assert_any_call(f'CREATE INDEX {table}_shape_idx ON {schema}.{table} USING GIST (shape);')
+        cursor.execute.assert_any_call(f'CREATE INDEX ON {schema}.{table} USING GIST (shape);')
         cursor.execute.assert_any_call('COMMIT;')
 
     @patch('psycopg.connect')
@@ -595,18 +596,18 @@ class SqlTests(TestCase):
         insert_fields = ['field1', 'field2']
         from_table = 'source_table'
         from_fields = ['field1', 'field2']
-
+        expected_q = f'''INSERT INTO {schema}.{insert_table} (shape, {','.join(insert_fields)}) SELECT ST_MakeValid(ST_TRANSFORM(shape, 3857)), {','.join(from_fields)} FROM {schema}.{from_table};'''
         # Call the function
         insert_from_db(cursor, schema, insert_table, insert_fields, from_table, from_fields)
 
         # Check if the correct SQL commands were executed
-        cursor.execute.assert_any_call('BEGIN;')
-        cursor.execute.assert_any_call(
-            f"insert into {schema}.{insert_table} (shape, {','.join(insert_fields)}) "
-            f"select ST_TRANSFORM(ST_MakeValid(shape), 4326), {','.join(from_fields)} "
-            f"from {schema}.{from_table};"
+        cursor.execute.assert_has_calls(
+            [
+                call('BEGIN;'),
+                call(expected_q),
+                call('COMMIT;')
+            ]
         )
-        cursor.execute.assert_any_call('COMMIT;')
 
     def test_copy_table_across_servers(self):
         from_cursor = MagicMock()
@@ -615,13 +616,56 @@ class SqlTests(TestCase):
         from_table = 'source_table'
         to_schema = 'public'
         to_table = 'destination_table'
+        from_columns = ['field1', 'field2']
+        to_columns = ['field1', 'field2']
 
-        copy_table_across_servers(from_cursor, from_schema, from_table, to_cursor, to_schema, to_table)
+        copy_table_across_servers(from_cursor, from_schema, from_table, to_cursor, to_schema, to_table, from_columns,
+                                  to_columns)
 
         from_cursor.copy.assert_called_once_with(
-            f"COPY (SELECT * FROM {from_schema}.{from_table}) TO STDOUT (FORMAT BINARY)")
-        to_cursor.execute.assert_any_call(f"DELETE FROM {to_schema}.{to_table};")
-        to_cursor.copy.assert_called_once_with(f"COPY {to_schema}.{to_table} FROM STDIN (FORMAT BINARY)")
+            f"COPY (SELECT field1,field2 FROM {from_schema}.{from_table}) TO STDOUT (FORMAT BINARY)")
+        assert call(f"DELETE FROM {to_schema}.{to_table};") not in to_cursor.execute.call_args_list
+        to_cursor.copy.assert_called_once_with(
+            f"COPY {to_schema}.{to_table} (field1,field2) FROM STDIN (FORMAT BINARY)")
+
+    def test_copy_table_across_servers_with_delete(self):
+        from_cursor = MagicMock()
+        to_cursor = MagicMock()
+        from_schema = 'public'
+        from_table = 'source_table'
+        to_schema = 'public'
+        to_table = 'destination_table'
+        from_columns = ['field1', 'field2']
+        to_columns = ['field1', 'field2']
+
+        copy_table_across_servers(from_cursor, from_schema, from_table, to_cursor, to_schema, to_table, from_columns,
+                                  to_columns, True)
+
+        from_cursor.copy.assert_called_once_with(
+            f"COPY (SELECT field1,field2 FROM {from_schema}.{from_table}) TO STDOUT (FORMAT BINARY)")
+        to_cursor.execute.assert_any_call(f"DELETE FROM {to_schema}.{to_table}")
+        to_cursor.copy.assert_called_once_with(
+            f"COPY {to_schema}.{to_table} (field1,field2) FROM STDIN (FORMAT BINARY)")
+
+    def test_copy_table_across_servers_with_delete_with_where(self):
+        from_cursor = MagicMock()
+        to_cursor = MagicMock()
+        from_schema = 'public'
+        from_table = 'source_table'
+        to_schema = 'public'
+        to_table = 'destination_table'
+        from_columns = ['field1', 'field2']
+        to_columns = ['field1', 'field2']
+
+        copy_table_across_servers(from_cursor, from_schema, from_table, to_cursor, to_schema, to_table, from_columns,
+                                  to_columns, True, 'field1 = 1')
+
+        from_cursor.copy.assert_called_once_with(
+            f"COPY (SELECT field1,field2 FROM {from_schema}.{from_table} WHERE field1 = 1) TO STDOUT (FORMAT BINARY)")
+        to_cursor.execute.assert_any_call(f"DELETE FROM {to_schema}.{to_table} WHERE field1 = 1")
+        to_cursor.copy.assert_called_once_with(
+            f"COPY {to_schema}.{to_table} (field1,field2) FROM STDIN (FORMAT BINARY)")
+
 
 class S3Tests(TestCase):
     def test_import_s3_csv_to_postgres_table(self):
@@ -644,7 +688,8 @@ class S3Tests(TestCase):
             [
                 call('BEGIN;'),
                 call(f'DELETE FROM {db_schema}.{destination_table};'),
-                call(f"""SELECT aws_s3.table_import_from_s3('{db_schema}.{destination_table}', '{",".join(fields)}', '(format csv, HEADER)', aws_commons.create_s3_uri('{s3_bucket}', '{csv_file}', '{aws_region}'));"""),
+                call(
+                    f"""SELECT aws_s3.table_import_from_s3('{db_schema}.{destination_table}', '{",".join(fields)}', '(format csv, HEADER)', aws_commons.create_s3_uri('{s3_bucket}', '{csv_file}', '{aws_region}'));"""),
                 call('COMMIT;')
             ]
         )

--- a/sweri_utils/tests.py
+++ b/sweri_utils/tests.py
@@ -394,9 +394,7 @@ class ConversionTests(TestCase):
         insert_from_db(mock_conn, 'dev', 'insert_here', ['field1', 'field2'],
                        'from_here', ['from1', 'from2'])
 
-        expected = f'''INSERT INTO dev.insert_here (shape, field1,field2) 
-            SELECT ST_MakeValid(ST_TRANSFORM(shape, 3857)), from1,from2 
-            FROM dev.from_here;'''
+        expected = f'''INSERT INTO dev.insert_here (shape, field1,field2) SELECT ST_MakeValid(ST_TRANSFORM(shape, 3857)), from1,from2 FROM dev.from_here;'''
         self.assertEqual(
             mock_conn.execute.call_args_list,
             [


### PR DESCRIPTION
Adds steps for indexing attribute and shape fields in the RDS intersection and intersection features tables. Switches over to using 3857 wkid for everything to stay consistent with staging and production tables and prevent costly reprojections. Fixes issue where temp table was not deleted. 
