### PR TITLE
Changes Daily Progression Upload to target only new features

### DIFF
--- a/daily_progression.py
+++ b/daily_progression.py
@@ -8,11 +8,10 @@ from arcgis.gis import GIS
 
 from sweri_utils.sql import connect_to_pg_db
 from sweri_utils.download import service_to_postgres
-from sweri_utils.hosted import hosted_upload_and_swizzle
+from sweri_utils.hosted import hosted_upload_and_swizzle, feature_append_workflow
 from sweri_utils.sweri_logging import logging, log_this
 
 logger = logging.getLogger(__name__)
-
 
 @log_this
 def import_current_fires_snapshot(current_fires_url, out_wkid, ogr_string, db_conn, schema):
@@ -206,6 +205,7 @@ if __name__ == '__main__':
     ogr_db_string = f"PG:dbname={os.getenv('DB_NAME')} user={os.getenv('DB_USER')} password={os.getenv('DB_PASSWORD')} port={os.getenv('DB_PORT')} host={os.getenv('DB_HOST')}"
 
     # Hosted upload variables
+    root_url = os.getenv('ESRI_ROOT_URL')
     gis_url = os.getenv("ESRI_PORTAL_URL")
     gis_user = os.getenv("ESRI_USER")
     gis_password = os.getenv("ESRI_PW")
@@ -215,7 +215,9 @@ if __name__ == '__main__':
     daily_progression_table = 'daily_progression'
 
     chunk = 1000
+    max_points_before_single_geom_chunk = 10000
     start_objectid = 0
+    where = f"(start_date = '{current_time_str}' or removal_date = '{one_second_ago_str}')"
 
     # import current fires layer into postgres
     import_current_fires_snapshot(wfigs_current_fires_url, wkid, ogr_db_string, conn, target_schema)
@@ -230,8 +232,13 @@ if __name__ == '__main__':
     # update entries modified since last run (inactivate old, add new)
     update_modified_fires(target_schema, conn, current_time_str, one_second_ago_str)
 
-    # update hosted feature layer with upload and swizzle
-    hosted_upload_and_swizzle(gis_url, gis_user, gis_password, daily_progression_view_id, daily_progression_data_ids, conn, target_schema,
-                              daily_progression_table, chunk, start_objectid)
+    # update hosted feature layer new features
+    try:
+        feature_append_workflow(root_url, gis_url, gis_user, gis_password, daily_progression_view_id, daily_progression_data_ids, target_schema, daily_progression_table,
+                       max_points_before_single_geom_chunk, chunk, where)
+
+    except Exception as e:
+        logging.error(f'An error occred while pdating this feature layer: {str(e)}')
+        raise
 
     conn.close()

--- a/sweri_utils/hosted.py
+++ b/sweri_utils/hosted.py
@@ -137,6 +137,74 @@ def hosted_upload_and_swizzle(root_url, gis_url, gis_user, gis_password, view_id
 
     return new_source_item.name
 
+@log_this
+def feature_append_workflow(root_url, gis_url, gis_user, gis_password, view_id, source_feature_layer_ids, schema, table, max_points_before_single_geom_chunk,
+                   chunk_size, where, shape=True, drop_cols=['objectid', 'gdb_geomattr_data']):
+
+    logging.info('Starting feature append workflow')
+    if not where:
+        logging.warning('No where clase provided, exiting append')
+        return
+
+    # setup new layer connection
+    gis_con = refresh_gis(gis_url, gis_user, gis_password)
+    view_item = gis_con.content.get(view_id)
+    logging.info(f'Retrieved view item: {view_item.name} ID: {view_id}')
+
+    original_data_source_id = get_view_data_source_id(view_item)
+    new_data_source_id = next(id for id in source_feature_layer_ids if id != original_data_source_id)
+    logging.info(f'Current source ID: {original_data_source_id}')
+    logging.info(f'New source ID: {new_data_source_id}')
+
+    conn = create_db_conn_from_envs()
+
+    # append and verify to new data source
+    append_and_verify(gis_url, gis_user, gis_password, conn, schema, table, where,
+                      max_points_before_single_geom_chunk, chunk_size, shape, drop_cols, new_data_source_id)
+
+    # swizzle so view is now using new feature layer as data source
+    view_item = gis_con.content.get(view_id)
+    new_source_item = gis_con.content.get(new_data_source_id)
+    token = gis_con.session.auth.token
+
+    logging.info(f'Swizzling view {view_item.name} to new data source {new_source_item.name}')
+    swizzle_service(root_url, view_item.name, new_source_item.name, token)
+
+    # append and verify to original source
+    append_and_verify(gis_url, gis_user, gis_password, conn, schema, table, where,
+                      max_points_before_single_geom_chunk, chunk_size, shape, drop_cols, original_data_source_id)
+
+
+def append_and_verify(gis_url, gis_user, gis_password, conn, schema, table, where,
+                       max_points_before_single_geom_chunk, chunk_size, shape, drop_cols, data_source_id):
+
+    logging.info(f'Appending data to data source: {data_source_id} where: {where}')
+
+    # list of tasks
+    t = []
+    if not shape:
+        # attribute only table, no geometry
+        for chunk_ids in get_object_id_chunks(conn, schema, table, where, chunk_size):
+            t.append(upload_chunk_to_feature_layer.s(gis_url, gis_user, gis_password, data_source_id, schema, table,
+                                                     chunk_ids, False, drop_cols))
+
+    else:
+
+        for chunk_ids in get_object_id_chunks(conn, schema, table, f'{where} and ST_NPoints(shape) > {max_points_before_single_geom_chunk}', 1):
+            t.append(upload_chunk_to_feature_layer.s(gis_url, gis_user, gis_password, data_source_id, schema, table,
+                                                     chunk_ids, shape, drop_cols))
+
+        for chunk_ids in get_object_id_chunks(conn, schema, table, f'{where} and ST_NPoints(shape) <= {max_points_before_single_geom_chunk}', chunk_size):
+            t.append(upload_chunk_to_feature_layer.s(gis_url, gis_user, gis_password, data_source_id, schema, table,
+                                                     chunk_ids, shape, drop_cols))
+    g = group(t)()
+    g.get()
+
+    logging.info(f'Verifying count in data source feature layer: {data_source_id}')
+    feature_layer = get_feature_layer_from_item(gis_url, gis_user, gis_password, data_source_id)
+    verify_feature_count(conn, schema, table, feature_layer)
+
+
 def get_feature_layer_from_item(gis_url, gis_user, gis_password,  new_data_source_id):
     gis_con = refresh_gis(gis_url, gis_user, gis_password)
     new_source_item = gis_con.content.get(new_data_source_id)


### PR DESCRIPTION
Uses a modified upload function that targets based on a provided where clause.

The where clause sets the start and removal date to the dates just used to add features to the db. 

The newly added, modified, and removed freatures are then added to the persistent hosted feature source layers without trunctating.

workflow uses:

daily prog view
daily prog data source 1
daily prog data source 2

steps:
view is looking at original data source
view is not looking at new data source

1) append changes to new data source
2) swizzle view to new data source
3) view is now looking at new data source
4) append changes to original data source