### PR TITLE
Use service as source for hazardous fuels. 

### DIFF
--- a/treatment_index/sweri_treatment_index.py
+++ b/treatment_index/sweri_treatment_index.py
@@ -263,7 +263,7 @@ def clear_response_cache(cache_info):
         for prefix in prefixes:
             delete_bucket_contents(bucket_name, prefix)
 
-def run_treatment_index(conn, schema, table, ogr_db_conn_string, wkid, facts_haz_fuels_gdb_url, nfpors_service_url,
+def run_treatment_index(conn, schema, table, ogr_db_conn_string, wkid, hazardous_fuels_service_url, nfpors_service_url,
                         ifprs_service_url, state_data_url, api_gis_url, api_gis_user, api_gis_password, ti_view_id,
                         ti_data_ids, additional_poly_view_ids, ti_points_view_id, ti_points_data_ids,
                         additional_point_views_ids, state_data_inclusion_flag, bucket, s3_obj_name, response_cache_info, ti_points_table='treatment_index_points',
@@ -281,14 +281,13 @@ def run_treatment_index(conn, schema, table, ogr_db_conn_string, wkid, facts_haz
 
     # Hazardous Fuels must finish before common_attributes starts, since CA strips out Hazardous Fuels entries
     facts_chain = chain(
-        hazardous_fuels_download_and_insert.s(
-            haz_fuels_table, facts_haz_fuels_gdb_url, facts_haz_gdb_path, wkid,
-            facts_haz_fuels_fc_name, schema, table, ogr_db_conn_string
-            ),
-            common_attributes_download_and_insert(
-                wkid, ogr_db_conn_string, schema, table, haz_fuels_table
-            ).set(immutable=True),
-        )
+        hazardous_fuels_download_and_insert(
+            schema, table, wkid, hazardous_fuels_service_url, ogr_db_conn_string
+        ),
+        common_attributes_download_and_insert(
+            wkid, ogr_db_conn_string, schema, table, haz_fuels_table
+        ).set(immutable=True),
+    )
 
     t.append(facts_chain)
     t.append(nfpors_download_and_insert.s(schema, table))
@@ -355,6 +354,7 @@ if __name__ == "__main__":
     exluded_ids = os.getenv('EXCLUSION_IDS')
     facts_haz_gdb_url = os.getenv('FACTS_GDB_URL')
     ifprs_url = os.getenv('IFPRS_URL')
+    hazardous_fuels_url = os.getenv('HAZARDOUS_FUELS_URL')
     facts_haz_gdb = 'Actv_HazFuelTrt_PL.gdb'
     facts_haz_fc_name = 'Actv_HazFuelTrt_PL'
     hazardous_fuels_table = 'facts_hazardous_fuels'
@@ -409,7 +409,7 @@ if __name__ == "__main__":
     # Set STATE_DATA_INCLUSION_FLAG to True to include state data
     include_state_data = os.getenv('STATE_DATA_INCLUSION_FLAG').lower() == 'true'
 
-    run_treatment_index(pg_conn, target_schema, insert_table, ogr_db_string, out_wkid, facts_haz_gdb_url, nfpors_url,
+    run_treatment_index(pg_conn, target_schema, insert_table, ogr_db_string, out_wkid, hazardous_fuels_url, nfpors_url,
                         ifprs_url, state_data_url, gis_url, gis_user, gis_password, treatment_index_view_id,
                         treatment_index_data_ids, additional_polygon_view_ids, treatment_index_points_view_id,
                         treatment_index_points_data_ids, additional_point_view_ids, include_state_data, s3_bucket, s3_obj,

--- a/treatment_index/tasks.py
+++ b/treatment_index/tasks.py
@@ -67,15 +67,17 @@ def nfpors_download_and_insert(schema, insert_table):
 
 #IFPRS Tasks
 
-def ifprs_download_and_insert(schema, insert_table, wkid, ifprs_url, ogr_db_string):
+def ifprs_download_and_insert(schema, insert_table, wkid, ifprs_url, ogr_db_string, where=None):
+
     # IFPRS processing and insert
-    where = '''
-        (Class IN ('Actual Treatment','Estimated Treatment')) AND 
-        ((completiondate > DATE '1984-01-01 00:00:00')
-        OR (completiondate IS NULL AND initiationdate > DATE '1984-01-01 00:00:00')
-        OR (completiondate IS NULL AND initiationdate IS NULL AND createdondate > DATE '1984-01-01 00:00:00')) AND
-        (EntityType = 'Fuels')
-    '''
+    if where is None:
+        where = '''
+            (Class IN ('Actual Treatment','Estimated Treatment')) AND 
+            ((completiondate > DATE '1984-01-01 00:00:00')
+            OR (completiondate IS NULL AND initiationdate > DATE '1984-01-01 00:00:00')
+            OR (completiondate IS NULL AND initiationdate IS NULL AND createdondate > DATE '1984-01-01 00:00:00')) AND
+            (EntityType = 'Fuels')
+        '''
     destination_table = 'ifprs'
     header = create_update_header_from_service(schema, destination_table, wkid, ifprs_url, ogr_db_string, where)
     return chord(header, ifprs_finalize_task.si(schema, insert_table, destination_table, ifprs_url, where))
@@ -197,8 +199,7 @@ def common_attributes_type_filter(schema, treatment_index):
         ''')
 
 # FACTS Hazardous Fuels Tasks
-def hazardous_fuels_download_and_insert(schema, treatment_index_table, wkid, hazardous_fuels_service_url, ogr_db_string):
-    where = '1=1'
+def hazardous_fuels_download_and_insert(schema, treatment_index_table, wkid, hazardous_fuels_service_url, ogr_db_string, where='1=1'):
     # FACTS Hazardous Fuels
     destination_table = 'facts_hazardous_fuels'
     header = create_update_header_from_service(schema, destination_table, wkid, hazardous_fuels_service_url, ogr_db_string, where, chunk_size=70)

--- a/treatment_index/tasks.py
+++ b/treatment_index/tasks.py
@@ -76,18 +76,20 @@ def ifprs_download_and_insert(schema, insert_table, wkid, ifprs_url, ogr_db_stri
         OR (completiondate IS NULL AND initiationdate IS NULL AND createdondate > DATE '1984-01-01 00:00:00')) AND
         (EntityType = 'Fuels')
     '''
-    header, destination_table = update_ifprs(schema, wkid, ifprs_url, ogr_db_string, where)
+    destination_table = 'ifprs'
+    header = create_update_header_from_service(schema, destination_table, wkid, ifprs_url, ogr_db_string, where)
     return chord(header, ifprs_finalize_task.si(schema, insert_table, destination_table, ifprs_url, where))
 
 
 @app.task()
-def update_ifprs(schema, wkid, service_url, ogr_db_string, where, chunk_size=70):
-    destination_table = 'ifprs'
+def create_update_header_from_service(schema, destination_table, wkid, service_url, ogr_db_string, where, chunk_size=70):
     out_fields = ['*']
 
     prep_buffer_table(schema, destination_table)
     try:
         ids = get_ids(service_url, where=where)
+        logger.info(f'Downloading {len(ids)} {destination_table} records')
+
         header = []
         for params in get_query_params_chunk(ids, wkid, out_fields, chunk_size):
             header.append(service_chunk_to_postgres.s(service_url, params, schema, destination_table, ogr_db_string))
@@ -95,7 +97,7 @@ def update_ifprs(schema, wkid, service_url, ogr_db_string, where, chunk_size=70)
     except Exception as e:
         logger.error(f'Error downloading IFPRS: {e}... continuing')
         pass
-    return header, destination_table
+    return header
 
 @app.task()
 def ifprs_finalize_task(schema, insert_table, destination_table, ifprs_url, where):
@@ -195,25 +197,20 @@ def common_attributes_type_filter(schema, treatment_index):
         ''')
 
 # FACTS Hazardous Fuels Tasks
+def hazardous_fuels_download_and_insert(schema, treatment_index_table, wkid, hazardous_fuels_service_url, ogr_db_string):
+    where = '1=1'
+    # FACTS Hazardous Fuels
+    destination_table = 'facts_hazardous_fuels'
+    header = create_update_header_from_service(schema, destination_table, wkid, hazardous_fuels_service_url, ogr_db_string, where, chunk_size=70)
+    return chord(header, hazardous_fuels_finalize_task.si(schema, treatment_index_table, destination_table, hazardous_fuels_service_url, where))
 
 @app.task()
-def hazardous_fuels_download_and_insert(hazardous_fuels_table, facts_haz_gdb_url, facts_haz_gdb, out_wkid, facts_haz_fc_name,
-                                        schema, insert_table, ogr_db_string):
-    # FACTS Hazardous Fuels
+def hazardous_fuels_finalize_task(schema, treatment_index_table, hazardous_fuels_table, service_url, where):
     conn = create_db_conn_from_envs()
-    hazardous_fuels_zip_file = f'{hazardous_fuels_table}.zip'
-    download_file_from_url(facts_haz_gdb_url, hazardous_fuels_zip_file)
-    extract_and_remove_zip_file(hazardous_fuels_zip_file)
 
-    # special input srs for common attributes
-    # https://gis.stackexchange.com/questions/112198/proj4-postgis-transformations-between-wgs84-and-nad83-transformations-in-alask
-    # without modifying the proj4 srs with the towgs84 values, the data is not in the "correct" location
-    input_srs = '+proj=longlat +datum=NAD83 +no_defs +type=crs +towgs84=-0.9956,1.9013,0.5215,0.025915,0.009426,0.011599,-0.00062'
-    gdb_to_postgres(facts_haz_gdb, out_wkid, facts_haz_fc_name, hazardous_fuels_table,
-                    schema, ogr_db_string, input_srs)
+    swap_buffer_table(schema, hazardous_fuels_table, service_url, where)
     hazardous_fuels_date_filtering(conn, schema, hazardous_fuels_table)
-    hazardous_fuels_insert(conn, schema, insert_table, hazardous_fuels_table)
-    remove_wildfire_non_treatment(conn, schema, insert_table)
+    hazardous_fuels_insert(conn, schema, treatment_index_table, hazardous_fuels_table)
 
 @app.task()
 def state_data_download_and_insert(state_data_url, wkid, schema, table, ogr_db_string):


### PR DESCRIPTION
Changes hazardous fuels import to use service instead of gdb. 

Makes update ifprs method into a generic that can also be used by hazardous fuels. 